### PR TITLE
Few tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,11 @@ FROM golang:alpine as build
 
 RUN apk add -U --no-cache ca-certificates git bash
 
-COPY ./ /go/src/github.com/kriechi/aws-s3-reverse-proxy
-WORKDIR /go/src/github.com/kriechi/aws-s3-reverse-proxy
+WORKDIR /app
+COPY . .
+# WORKDIR /go/src/github.com/kriechi/aws-s3-reverse-proxy
 
-RUN go build -o aws-s3-reverse-proxy github.com/kriechi/aws-s3-reverse-proxy && \
+RUN go build -o aws-s3-reverse-proxy && \
     mv ./aws-s3-reverse-proxy /go/bin
 
 FROM alpine:3.10

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ RUN apk add -U --no-cache ca-certificates git bash
 
 WORKDIR /app
 COPY . .
-# WORKDIR /go/src/github.com/kriechi/aws-s3-reverse-proxy
 
 RUN go build -o aws-s3-reverse-proxy && \
     mv ./aws-s3-reverse-proxy /go/bin

--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ $ docker run --rm -ti \
   --aws-credentials=AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY
 ```
 
+You can also use env variables
+```
+$ docker run --rm -ti \
+  -p 8099 \
+  -e ALLOWED_SOURCE_SUBNET=192.168.1.0/24 \
+  -e ALLOWED_ENDPOINT=my.host.example.com:8099 \
+  -e AWS_CREDENTIALS=AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY
+  aws-s3-reverse-proxy
+```
+
 Or you can use a config file:
 ```
 # config.cfg file for aws-3-reverse-proxy

--- a/handler.go
+++ b/handler.go
@@ -17,7 +17,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var awsAuthorizationCredentialRegexp = regexp.MustCompile("Credential=([a-zA-Z0-9]+)/[0-9]+/([a-z]+-[a-z]+-[0-9]+)/s3/aws4_request")
+var awsAuthorizationCredentialRegexp = regexp.MustCompile("Credential=([a-zA-Z0-9]+)/[0-9]+/([a-z]+-?[a-z]+-?[0-9]+)/s3/aws4_request")
 var awsAuthorizationSignedHeadersRegexp = regexp.MustCompile("SignedHeaders=([a-zA-Z0-9;-]+)")
 
 // Handler is a special handler that re-signs any AWS S3 request and sends it upstream

--- a/main.go
+++ b/main.go
@@ -35,18 +35,18 @@ type Options struct {
 // NewOptions defines and parses the raw command line arguments
 func NewOptions() Options {
 	var opts Options
-	kingpin.Flag("verbose", "enable additional logging").Short('v').BoolVar(&opts.Debug)
-	kingpin.Flag("listen-addr", "address:port to listen for requests on").Default(":8099").StringVar(&opts.ListenAddr)
-	kingpin.Flag("metrics-listen-addr", "address:port to listen for Prometheus metrics on, empty to disable").Default("").StringVar(&opts.MetricsListenAddr)
-	kingpin.Flag("pprof-listen-addr", "address:port to listen for pprof on, empty to disable").Default("").StringVar(&opts.PprofListenAddr)
-	kingpin.Flag("allowed-endpoint", "allowed endpoint (Host header) to accept for incoming requests").Required().PlaceHolder("my.host.example.com:8099").StringVar(&opts.AllowedSourceEndpoint)
-	kingpin.Flag("allowed-source-subnet", "allowed source IP addresses with netmask").Default("127.0.0.1/32").StringsVar(&opts.AllowedSourceSubnet)
-	kingpin.Flag("aws-credentials", "set of AWS credentials").PlaceHolder("\"AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY\"").StringsVar(&opts.AwsCredentials)
-	kingpin.Flag("aws-region", "send requests to this AWS S3 region").Default("eu-central-1").StringVar(&opts.Region)
-	kingpin.Flag("upstream-insecure", "use insecure HTTP for upstream connections").BoolVar(&opts.UpstreamInsecure)
-	kingpin.Flag("upstream-endpoint", "use this S3 endpoint for upstream connections, instead of public AWS S3").StringVar(&opts.UpstreamEndpoint)
-	kingpin.Flag("cert-file", "path to the certificate file").Default("").StringVar(&opts.CertFile)
-	kingpin.Flag("key-file", "path to the private key file").Default("").StringVar(&opts.KeyFile)
+	kingpin.Flag("verbose", "enable additional logging (env - VERBOSE)").Envar("VERBOSE").Short('v').BoolVar(&opts.Debug)
+	kingpin.Flag("listen-addr", "address:port to listen for requests on").Default(":8099").Envar("LISTEN_ADDR").StringVar(&opts.ListenAddr)
+	kingpin.Flag("metrics-listen-addr", "address:port to listen for Prometheus metrics on, empty to disable").Default("").Envar("METRICS_LISTEN_ADDR").StringVar(&opts.MetricsListenAddr)
+	kingpin.Flag("pprof-listen-addr", "address:port to listen for pprof on, empty to disable").Default("").Envar("PPROF_LISTEN_ADDR").StringVar(&opts.PprofListenAddr)
+	kingpin.Flag("allowed-endpoint", "allowed endpoint (Host header) to accept for incoming requests").Envar("ALLOWED_ENDPOINT").Required().PlaceHolder("my.host.example.com:8099").StringVar(&opts.AllowedSourceEndpoint)
+	kingpin.Flag("allowed-source-subnet", "allowed source IP addresses with netmask").Default("127.0.0.1/32").Envar("ALLOWED_SOURCE_SUBNET").StringsVar(&opts.AllowedSourceSubnet)
+	kingpin.Flag("aws-credentials", "set of AWS credentials").PlaceHolder("\"AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY\"").Envar("AWS_CREDENTIALS").StringsVar(&opts.AwsCredentials)
+	kingpin.Flag("aws-region", "send requests to this AWS S3 region").Envar("AWS_REGION").Default("eu-central-1").StringVar(&opts.Region)
+	kingpin.Flag("upstream-insecure", "use insecure HTTP for upstream connections").Envar("UPSTREAM_INSECURE").BoolVar(&opts.UpstreamInsecure)
+	kingpin.Flag("upstream-endpoint", "use this S3 endpoint for upstream connections, instead of public AWS S3").Envar("UPSTREAM_ENDPOINT").StringVar(&opts.UpstreamEndpoint)
+	kingpin.Flag("cert-file", "path to the certificate file").Envar("CERT_FILE").Default("").StringVar(&opts.CertFile)
+	kingpin.Flag("key-file", "path to the private key file").Envar("KEY_FILE").Default("").StringVar(&opts.KeyFile)
 	kingpin.Parse()
 	return opts
 }

--- a/main.go
+++ b/main.go
@@ -36,17 +36,17 @@ type Options struct {
 func NewOptions() Options {
 	var opts Options
 	kingpin.Flag("verbose", "enable additional logging (env - VERBOSE)").Envar("VERBOSE").Short('v').BoolVar(&opts.Debug)
-	kingpin.Flag("listen-addr", "address:port to listen for requests on").Default(":8099").Envar("LISTEN_ADDR").StringVar(&opts.ListenAddr)
-	kingpin.Flag("metrics-listen-addr", "address:port to listen for Prometheus metrics on, empty to disable").Default("").Envar("METRICS_LISTEN_ADDR").StringVar(&opts.MetricsListenAddr)
-	kingpin.Flag("pprof-listen-addr", "address:port to listen for pprof on, empty to disable").Default("").Envar("PPROF_LISTEN_ADDR").StringVar(&opts.PprofListenAddr)
-	kingpin.Flag("allowed-endpoint", "allowed endpoint (Host header) to accept for incoming requests").Envar("ALLOWED_ENDPOINT").Required().PlaceHolder("my.host.example.com:8099").StringVar(&opts.AllowedSourceEndpoint)
-	kingpin.Flag("allowed-source-subnet", "allowed source IP addresses with netmask").Default("127.0.0.1/32").Envar("ALLOWED_SOURCE_SUBNET").StringsVar(&opts.AllowedSourceSubnet)
-	kingpin.Flag("aws-credentials", "set of AWS credentials").PlaceHolder("\"AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY\"").Envar("AWS_CREDENTIALS").StringsVar(&opts.AwsCredentials)
-	kingpin.Flag("aws-region", "send requests to this AWS S3 region").Envar("AWS_REGION").Default("eu-central-1").StringVar(&opts.Region)
-	kingpin.Flag("upstream-insecure", "use insecure HTTP for upstream connections").Envar("UPSTREAM_INSECURE").BoolVar(&opts.UpstreamInsecure)
-	kingpin.Flag("upstream-endpoint", "use this S3 endpoint for upstream connections, instead of public AWS S3").Envar("UPSTREAM_ENDPOINT").StringVar(&opts.UpstreamEndpoint)
-	kingpin.Flag("cert-file", "path to the certificate file").Envar("CERT_FILE").Default("").StringVar(&opts.CertFile)
-	kingpin.Flag("key-file", "path to the private key file").Envar("KEY_FILE").Default("").StringVar(&opts.KeyFile)
+	kingpin.Flag("listen-addr", "address:port to listen for requests on (env - LISTEN_ADDR)").Default(":8099").Envar("LISTEN_ADDR").StringVar(&opts.ListenAddr)
+	kingpin.Flag("metrics-listen-addr", "address:port to listen for Prometheus metrics on, empty to disable (env - METRICS_LISTEN_ADDR)").Default("").Envar("METRICS_LISTEN_ADDR").StringVar(&opts.MetricsListenAddr)
+	kingpin.Flag("pprof-listen-addr", "address:port to listen for pprof on, empty to disable (env - PPROF_LISTEN_ADDR)").Default("").Envar("PPROF_LISTEN_ADDR").StringVar(&opts.PprofListenAddr)
+	kingpin.Flag("allowed-endpoint", "allowed endpoint (Host header) to accept for incoming requests (env - ALLOWED_ENDPOINT)").Envar("ALLOWED_ENDPOINT").Required().PlaceHolder("my.host.example.com:8099").StringVar(&opts.AllowedSourceEndpoint)
+	kingpin.Flag("allowed-source-subnet", "allowed source IP addresses with netmask (env - ALLOWED_SOURCE_SUBNET)").Default("127.0.0.1/32").Envar("ALLOWED_SOURCE_SUBNET").StringsVar(&opts.AllowedSourceSubnet)
+	kingpin.Flag("aws-credentials", "set of AWS credentials (env - AWS_CREDENTIALS)").PlaceHolder("\"AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY\"").Envar("AWS_CREDENTIALS").StringsVar(&opts.AwsCredentials)
+	kingpin.Flag("aws-region", "send requests to this AWS S3 region (env - AWS_REGION)").Envar("AWS_REGION").Default("eu-central-1").StringVar(&opts.Region)
+	kingpin.Flag("upstream-insecure", "use insecure HTTP for upstream connections (env - UPSTREAM_INSECURE)").Envar("UPSTREAM_INSECURE").BoolVar(&opts.UpstreamInsecure)
+	kingpin.Flag("upstream-endpoint", "use this S3 endpoint for upstream connections, instead of public AWS S3 (env - UPSTREAM_ENDPOINT)").Envar("UPSTREAM_ENDPOINT").StringVar(&opts.UpstreamEndpoint)
+	kingpin.Flag("cert-file", "path to the certificate file (env - CERT_FILE)").Envar("CERT_FILE").Default("").StringVar(&opts.CertFile)
+	kingpin.Flag("key-file", "path to the private key file (env - KEY_FILE)").Envar("KEY_FILE").Default("").StringVar(&opts.KeyFile)
 	kingpin.Parse()
 	return opts
 }

--- a/main.go
+++ b/main.go
@@ -126,9 +126,11 @@ func main() {
 		http.DefaultServeMux = http.NewServeMux()
 		// https://golang.org/pkg/net/http/pprof/
 		log.Infof("Listening for pprof connections on %s", opts.PprofListenAddr)
-		go log.Fatal(
-			http.ListenAndServe(opts.PprofListenAddr, pprofMux),
-		)
+		go func() {
+			log.Fatal(
+				http.ListenAndServe(opts.PprofListenAddr, pprofMux),
+			)
+		}()
 	}
 
 	var wrappedHandler http.Handler = handler
@@ -137,10 +139,13 @@ func main() {
 		metricsHandler.Handle("/metrics", promhttp.Handler())
 
 		log.Infof("Listening for secure Prometheus metrics on %s", opts.MetricsListenAddr)
-		go log.Fatal(
-			http.ListenAndServe(opts.MetricsListenAddr, metricsHandler),
-		)
 		wrappedHandler = wrapPrometheusMetrics(handler)
+
+		go func() {
+			log.Fatal(
+				http.ListenAndServe(opts.MetricsListenAddr, metricsHandler),
+			)
+		}()
 	}
 
 	if len(opts.CertFile) > 0 || len(opts.KeyFile) > 0 {

--- a/metrics.go
+++ b/metrics.go
@@ -10,26 +10,26 @@ import (
 func wrapPrometheusMetrics(handler http.Handler) http.Handler {
 	counter := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "api_requests_total",
+			Name: "s3proxy_api_requests_total",
 			Help: "A counter for requests to the wrapped handler.",
 		},
 		[]string{"code", "method"},
 	)
 	duration := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "request_duration_seconds",
+			Name:    "s3proxy_request_duration_seconds",
 			Help:    "A histogram of latencies for requests.",
 			Buckets: []float64{.25, .5, 0.75, 1, 2.5, 5, 10},
 		},
 		[]string{"handler", "method"},
 	)
 	inFlight := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "in_flight_requests",
+		Name: "s3proxy_in_flight_requests",
 		Help: "A gauge of requests currently being served by the wrapped handler.",
 	})
 	requestSize := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "request_size_bytes",
+			Name:    "s3proxy_request_size_bytes",
 			Help:    "A histogram of request sizes.",
 			Buckets: []float64{200, 500, 900, 1500, 4100, 8200, 16400, 32800},
 		},
@@ -37,7 +37,7 @@ func wrapPrometheusMetrics(handler http.Handler) http.Handler {
 	)
 	responseSize := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "response_size_bytes",
+			Name:    "s3proxy_response_size_bytes",
 			Help:    "A histogram of response sizes for requests.",
 			Buckets: []float64{200, 500, 900, 1500, 4100, 8200, 16400, 32800},
 		},
@@ -45,7 +45,7 @@ func wrapPrometheusMetrics(handler http.Handler) http.Handler {
 	)
 	timeToWriteHeader := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "time_to_write_header",
+			Name:    "s3proxy_time_to_write_header",
 			Help:    "A histogram of time to write heaer.",
 			Buckets: []float64{0.25, 0.5, 0.75, 1, 2.5, 5, 10},
 		},


### PR DESCRIPTION
- Not using full packet path in dockerfile, so case sensitive errors don't occur(kriechi/Kriechi)
- More permissive regex, to allow slightly different type of region.(ams3 region in DO Spaces don't have dashes in it - AWS4-HMAC-SHA256 Credential=6K5QTQPYH7JAPSB6YCNH/20210420/ams3/s3/aws4_request)
- call log.Fatal(http.ListenAndServ... inside goroutine function, otherwise it behaves same as without go keyword.
- Add prefix to Prometheus metrics.
- Add env variants to arguments.